### PR TITLE
Fixing missing hostname in docker-compose for ts-isr

### DIFF
--- a/solution/ts-isr/docker-compose.yml
+++ b/solution/ts-isr/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.5"
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.1.2
+    hostname: zookeeper
     networks:
       - confluent
     environment:


### PR DESCRIPTION
Fixes https://github.com/confluentinc/training-cao/issues/234